### PR TITLE
Command Line Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Now I'm on a mission to bring the power and elegance of Lisp to the web, while a
 
 ## Language features
 
-*Note: this section includes features that are still under development*
+_Note: this section includes features that are still under development_
 
 - Lisp-style syntax, programs as data, and macros
 - The best features of both functional and object-oriented paradigms
@@ -37,6 +37,8 @@ Now I'm on a mission to bring the power and elegance of Lisp to the web, while a
 ## Using the interpreter and transpiler
 
 Start by cloning the repo: `git clone https://github.com/jasonsbarr/arith.git <directory>`.
+
+`cd` into directory created by previous command.
 
 Install dependencies with `npm install`.
 

--- a/bin/arith
+++ b/bin/arith
@@ -49,18 +49,19 @@ const run = (argv) => {
           ),
         );
         console.log("Enjoy!");
-
-        process.exit(0);
+        break;
       case "version":
         console.log(`Arith ${version}`);
+        break;
       case "run":
         const input = fs.readFileSync(args[0], "utf-8");
-
         print(evaluate(input));
+        break;
       default:
         console.log(evaluate(argv.slice(2).join("")));
-        process.exit(0);
+        break;
     }
+    process.exit(0);
   }
 };
 

--- a/bin/arith
+++ b/bin/arith
@@ -12,47 +12,55 @@ const version = JSON.parse(
 
 const run = (argv) => {
   const [command, ...args] = argv.slice(2);
-
-  if (!command || command === "i") {
+  if (argv.length === 2 || command === "i") {
     const { repl } = require("../src/repl");
     repl();
-  } else if (command.toLowerCase() === "help") {
-    console.log(
-      chalk.cyan(
-        "Welcome to Arith - a simple, Lisp-like programming language.\n",
-      ),
-    );
-    console.log(`You are using Arith ${version}`);
-    console.log(chalk.blue("Here are the valid commands:\n"));
-    console.log("COMMAND", "                DESCRIPTION");
-    console.log(
-      "<none>, i",
-      "              Open the interpreter in interactive/REPL mode",
-    );
-    console.log("help", "                   Print this help message");
-    console.log(
-      "version",
-      "                Print the version of Arith you're using",
-    );
-    console.log(
-      "run",
-      "                    Execute the contents of a valid Arith file",
-    );
-    console.log(); // blank line
-    console.log(
-      chalk.cyan(
-        "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
-      ),
-    );
-    console.log("Enjoy!");
+  } else {
+    switch (command.toLowerCase()) {
+      case "help":
+        console.log(
+          chalk.cyan(
+            "Welcome to Arith - a simple, Lisp-like programming language.\n",
+          ),
+        );
+        console.log(`You are using Arith ${version}`);
+        console.log(chalk.blue("Here are the valid commands:\n"));
+        console.log("COMMAND", "                DESCRIPTION");
+        console.log(
+          "<none>, i",
+          "              Open the interpreter in interactive/REPL mode",
+        );
+        console.log(
+          "help",
+          "                   Print this help message",
+        );
+        console.log(
+          "version",
+          "                Print the version of Arith you're using",
+        );
+        console.log(
+          "run",
+          "                    Execute the contents of a valid Arith file",
+        );
+        console.log(); // blank line
+        console.log(
+          chalk.cyan(
+            "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
+          ),
+        );
+        console.log("Enjoy!");
 
-    process.exit(0);
-  } else if (command.toLowerCase() === "version") {
-    console.log(`Arith ${version}`);
-  } else if (command.toLowerCase() === "run") {
-    const input = fs.readFileSync(args[0], "utf-8");
+        process.exit(0);
+      case "version":
+        console.log(`Arith ${version}`);
+      case "run":
+        const input = fs.readFileSync(args[0], "utf-8");
 
-    print(evaluate(input));
+        print(evaluate(input));
+      default:
+        console.log(evaluate(argv.slice(2).join("")));
+        process.exit(0);
+    }
   }
 };
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -2,6 +2,8 @@
 
 Start by cloning the repo: `git clone https://github.com/jasonsbarr/arith.git <directory>`.
 
+`cd` into directory created by previous command.
+
 Install dependencies with `npm install`.
 
 You'll need to run `npm link` from the project directory if you want the commands to be available in your global path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arith",
-  "version": "0.10.1",
+  "version": "0.11.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -820,6 +820,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       },
@@ -827,7 +828,8 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
         }
       }
     },
@@ -1203,11 +1205,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1236,19 +1233,6 @@
           }
         }
       }
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -1530,7 +1514,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -1553,7 +1538,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.1",
@@ -1704,16 +1690,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -1809,14 +1785,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
       }
     },
     "fill-range": {
@@ -2067,6 +2035,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2107,37 +2076,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
-      }
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -2234,7 +2172,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -2256,11 +2195,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3179,7 +3113,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -3263,7 +3198,8 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3306,11 +3242,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3490,6 +3421,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -3507,11 +3439,6 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-each-series": {
       "version": "2.1.0",
@@ -3910,15 +3837,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -3940,22 +3858,6 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
-    "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
-    },
-    "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -3974,7 +3876,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -4186,7 +4089,8 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -4485,6 +4389,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4495,6 +4400,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       },
@@ -4502,7 +4408,8 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         }
       }
     },
@@ -4574,19 +4481,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -4660,11 +4554,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "decimal.js": "^10.2.0",
     "fast-deep-equal": "^3.1.1",
     "immutable": "^4.0.0-rc.12",
-    "inquirer": "^7.1.0",
     "list": "^2.0.19",
     "ramda": "^0.27.0",
     "readline-sync": "^1.4.10",

--- a/src/repl.js
+++ b/src/repl.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const { prompt } = require("inquirer");
+const readline = require("readline");
 const chalk = require("chalk");
 const { evaluate } = require("./evaluate");
 
@@ -8,31 +8,118 @@ const version = JSON.parse(
   fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8"),
 ).version;
 
-const getInput = () => {
-  const input = [
-    {
-      name: "INPUT",
-      type: "input",
-      prefix: chalk.green(`(arith v${version}):`),
-      message: ">",
-    },
-  ];
+const repl = () => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: `${chalk.green(`(arith v${version}):`)} ${chalk.white(
+      "> ",
+    )}`,
+  });
+  rl.prompt();
 
-  return prompt(input);
-};
-
-const repl = async () => {
-  try {
-    const { INPUT } = await getInput();
-
-    if (INPUT.trim()) {
-      console.log(chalk.yellow(evaluate(INPUT)));
+  rl.on("line", (line) => {
+    if (line.trim() === "") {
+      return rl.prompt();
     }
-  } catch (e) {
-    console.error(e);
-  }
-
-  repl();
+    switch (line.trim()) {
+      case ".end":
+        console.log("Have a nice day!");
+        process.exit(0);
+      case ".q":
+        console.log("Have a nice day!");
+        process.exit(0);
+      case ".quit":
+        console.log("Have a nice day!");
+        process.exit(0);
+      case "quit":
+        console.log("Have a nice day!");
+        process.exit(0);
+      case ".exit":
+        console.log("Have a nice day!");
+        process.exit(0);
+      case "exit":
+        console.log("Have a nice day!");
+        process.exit(0);
+      case ".help":
+        console.log(
+          chalk.cyan(
+            "Welcome to Arith - a simple, Lisp-like programming language.\n",
+          ),
+        );
+        console.log(`You are using Arith ${version}`);
+        console.log(chalk.blue("Here are the valid commands:\n"));
+        console.log("COMMAND", "                DESCRIPTION");
+        console.log(
+          "<none>, i",
+          "              Open the interpreter in interactive/REPL mode",
+        );
+        console.log(
+          "help",
+          "                   Print this help message",
+        );
+        console.log(
+          "version",
+          "                Print the version of Arith you're using",
+        );
+        console.log(
+          "run",
+          "                    Execute the contents of a valid Arith file",
+        );
+        console.log(); // blank line
+        console.log(
+          chalk.cyan(
+            "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
+          ),
+        );
+        console.log("Enjoy!");
+        break;
+      case "help":
+        console.log(
+          chalk.cyan(
+            "Welcome to Arith - a simple, Lisp-like programming language.\n",
+          ),
+        );
+        console.log(`You are using Arith ${version}`);
+        console.log(chalk.blue("Here are the valid commands:\n"));
+        console.log("COMMAND", "                DESCRIPTION");
+        console.log(
+          "<none>, i",
+          "              Open the interpreter in interactive/REPL mode",
+        );
+        console.log(
+          "help",
+          "                   Print this help message",
+        );
+        console.log(
+          "version",
+          "                Print the version of Arith you're using",
+        );
+        console.log(
+          "run",
+          "                    Execute the contents of a valid Arith file",
+        );
+        console.log(); // blank line
+        console.log(
+          chalk.cyan(
+            "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
+          ),
+        );
+        console.log("Enjoy!");
+        break;
+      default:
+        try {
+          console.log(chalk.yellow(evaluate(line.trim())));
+        } catch (err) {
+          console.error(err);
+        }
+        break;
+    }
+    rl.prompt();
+  }).on("close", () => {
+    console.log("Have a nice day!");
+    process.exit(0);
+  });
 };
 
 if (require.main === module) {


### PR DESCRIPTION
## Adds:
- `readline` package
- Note about changing directories before installing dependencies (same as previous now closed PR, I just forgot to base this branch off of master instead of that branch, so this is a two-for).

- Commands for quitting the repl and logging to console the message "Have a nice day!":
    - .end
    - .q
    - .quit
    - quit
    - .exit
    - exit

- Commands for pulling up the help menu:
    - help
    - .help

- The ability to run the program by passing the expression to arith (not starting the repl).
    Example usage:
    > `arith '(print "Hello, world") ; -> "Hello, world"'`

    It should be noted that certain characters need to be escaped or the entire expression needs to be wrapped with single quotes (assuming that there is no expression that would contain single quotes).

    The escaped version would be:
    > `arith "(print \"Hello, world\") ; -> \"Hello, world\""`

    It should also be noted that all expressions must be wrapped by some quotation mechanism or the shell program will throw an annoying error about unknown file attributes.  Fun times.

### Removes:
- `inquirer` package

### Changes:
- If/else if/else statement in `bin/arith` to a switch statement

#### Notes:
- Created a bug where `arith version` and `arith run <file>` commands were broken, resolved by remembering to add `break` statements in switch statement.  Added a process.exit(0) for good measure, just in case.  