### PR TITLE
Converting to repl

### DIFF
--- a/bin/arith
+++ b/bin/arith
@@ -11,11 +11,22 @@ const version = JSON.parse(
 ).version;
 
 const run = (argv) => {
+  const fileName = argv[2];
+  let validExtensions = /\.(txt|jsx?|tsx?)$/g;
+  if (validExtensions.test(fileName)) {
+    const input = fs.readFileSync(fileName, "utf-8");
+    print(evaluate(input));
+    process.exit();
+  }
   const [command, ...args] = argv.slice(2);
-
   if (!command || command === "i") {
-    const { repl } = require("../src/repl");
-    repl();
+    const { initializeRepl } = require("../src/repl");
+    console.log(
+      chalk.cyan(
+        "Welcome to Arith - a simple, Lisp-like programming language.\nType .help for help, .load to load a file, .exit to exit\n",
+      ),
+    );
+    initializeRepl();
   } else if (command.toLowerCase() === "help") {
     console.log(
       chalk.cyan(
@@ -35,7 +46,7 @@ const run = (argv) => {
       "                Print the version of Arith you're using",
     );
     console.log(
-      "run",
+      "<filename> or run <filename>",
       "                    Execute the contents of a valid Arith file",
     );
     console.log(); // blank line

--- a/bin/arith
+++ b/bin/arith
@@ -12,7 +12,7 @@ const version = JSON.parse(
 
 const run = (argv) => {
   const fileName = argv[2];
-  let validExtensions = /\.(txt|jsx?|tsx?)$/g;
+  let validExtensions = /\.arith$/g;
   if (validExtensions.test(fileName)) {
     const input = fs.readFileSync(fileName, "utf-8");
     print(evaluate(input));
@@ -29,6 +29,10 @@ const run = (argv) => {
     initializeRepl();
   } else {
     switch (command.toLowerCase()) {
+      case "eval":
+        const input = args[0].trim();
+        print(evaluate(input));
+        break;
       case "help":
         console.log(
           chalk.cyan(
@@ -42,6 +46,7 @@ const run = (argv) => {
           "<none>, i",
           "\t\t\t\tOpen the interpreter in interactive/REPL mode",
         );
+        console.log("eval", "\t\t\t\t\tEvaluate an expression");
         console.log("help", "\t\t\t\t\tPrint this help message");
         console.log(
           "version",
@@ -100,9 +105,7 @@ const run = (argv) => {
         print(evaluate(fileInput));
         break;
       default:
-        const input = command.trim();
-        print(evaluate(input));
-        break;
+        process.exit(0);
     }
     process.exit(0);
   }

--- a/bin/arith
+++ b/bin/arith
@@ -23,47 +23,88 @@ const run = (argv) => {
     const { initializeRepl } = require("../src/repl");
     console.log(
       chalk.cyan(
-        "Welcome to Arith - a simple, Lisp-like programming language.\nType .help for help, .load to load a file, .exit to exit\n",
+        "Welcome to Arith - a simple, Lisp-like programming language.\nType .help for help, .editor to enter multi-line mode, .exit to exit\n",
       ),
     );
     initializeRepl();
-  } else if (command.toLowerCase() === "help") {
-    console.log(
-      chalk.cyan(
-        "Welcome to Arith - a simple, Lisp-like programming language.\n",
-      ),
-    );
-    console.log(`You are using Arith ${version}`);
-    console.log(chalk.blue("Here are the valid commands:\n"));
-    console.log("COMMAND", "                DESCRIPTION");
-    console.log(
-      "<none>, i",
-      "              Open the interpreter in interactive/REPL mode",
-    );
-    console.log("help", "                   Print this help message");
-    console.log(
-      "version",
-      "                Print the version of Arith you're using",
-    );
-    console.log(
-      "<filename> or run <filename>",
-      "                    Execute the contents of a valid Arith file",
-    );
-    console.log(); // blank line
-    console.log(
-      chalk.cyan(
-        "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
-      ),
-    );
-    console.log("Enjoy!");
-
+  } else {
+    switch (command.toLowerCase()) {
+      case "help":
+        console.log(
+          chalk.cyan(
+            "Welcome to Arith - a simple, Lisp-like programming language.\n",
+          ),
+        );
+        console.log(`You are using Arith ${version}`);
+        console.log(chalk.blue("Here are the valid commands:\n"));
+        console.log("COMMAND", "\t\t\t\tDESCRIPTION");
+        console.log(
+          "<none>, i",
+          "\t\t\t\tOpen the interpreter in interactive/REPL mode",
+        );
+        console.log("help", "\t\t\t\t\tPrint this help message");
+        console.log(
+          "version",
+          "\t\t\t\tPrint the version of Arith you're using",
+        );
+        console.log(
+          "<filename> or run <filename>",
+          "\t\tExecute the contents of a valid Arith file",
+        );
+        console.log(); // blank line
+        console.log(
+          chalk.cyan(
+            "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
+          ),
+        );
+        console.log("Enjoy!");
+        break;
+      case ".help":
+        console.log(
+          chalk.cyan(
+            "Welcome to Arith - a simple, Lisp-like programming language.\n",
+          ),
+        );
+        console.log(`You are using Arith ${version}`);
+        console.log(chalk.blue("Here are the valid commands:\n"));
+        console.log("COMMAND", "\t\t\t\tDESCRIPTION");
+        console.log(
+          "<none>, i",
+          "\t\t\t\tOpen the interpreter in interactive/REPL mode",
+        );
+        console.log("help", "\t\t\t\t\tPrint this help message");
+        console.log(
+          "version",
+          "\t\t\t\tPrint the version of Arith you're using",
+        );
+        console.log(
+          "<filename> or run <filename>",
+          "\t\tExecute the contents of a valid Arith file",
+        );
+        console.log(); // blank line
+        console.log(
+          chalk.cyan(
+            "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
+          ),
+        );
+        console.log("Enjoy!");
+        break;
+      case "version":
+        console.log(`Arith ${version}`);
+        break;
+      case ".version":
+        console.log(`Arith ${version}`);
+        break;
+      case "run":
+        const fileInput = fs.readFileSync(args[0], "utf-8");
+        print(evaluate(fileInput));
+        break;
+      default:
+        const input = command.trim();
+        print(evaluate(input));
+        break;
+    }
     process.exit(0);
-  } else if (command.toLowerCase() === "version") {
-    console.log(`Arith ${version}`);
-  } else if (command.toLowerCase() === "run") {
-    const input = fs.readFileSync(args[0], "utf-8");
-
-    print(evaluate(input));
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arith",
-  "version": "0.10.1",
+  "version": "0.11.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -820,6 +820,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       },
@@ -827,7 +828,8 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
         }
       }
     },
@@ -1203,11 +1205,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1236,19 +1233,6 @@
           }
         }
       }
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -1530,7 +1514,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -1553,7 +1538,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.1",
@@ -1704,16 +1690,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -1809,14 +1785,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
       }
     },
     "fill-range": {
@@ -2067,6 +2035,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2107,37 +2076,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
-      }
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -2234,7 +2172,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -2256,11 +2195,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3179,7 +3113,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -3263,7 +3198,8 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3306,11 +3242,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3490,6 +3421,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -3507,11 +3439,6 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-each-series": {
       "version": "2.1.0",
@@ -3910,15 +3837,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -3940,22 +3858,6 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
-    "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
-    },
-    "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -3974,7 +3876,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -4186,7 +4089,8 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -4485,6 +4389,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4495,6 +4400,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       },
@@ -4502,7 +4408,8 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         }
       }
     },
@@ -4574,19 +4481,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -4660,11 +4554,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "decimal.js": "^10.2.0",
     "fast-deep-equal": "^3.1.1",
     "immutable": "^4.0.0-rc.12",
-    "inquirer": "^7.1.0",
     "list": "^2.0.19",
     "ramda": "^0.27.0",
     "readline-sync": "^1.4.10",

--- a/src/help.js
+++ b/src/help.js
@@ -1,9 +1,0 @@
-let help = [
-  [".editor", "Enter editor mode, to allow multi-line expressions"],
-  [".exit", "Exit the Arith REPL"],
-  [".help", "Display the valid commands for Arith"],
-  [".load", "Load a file"],
-  [".save <path/to/file>", "Save a REPL session as a file"],
-  [".version", "Print the version of Arith you're using"],
-];
-module.exports = { help };

--- a/src/help.js
+++ b/src/help.js
@@ -1,5 +1,4 @@
 let help = [
-  ["<none>, i", "Open the interpreter in interactive/REPL mode"],
   [".editor", "Enter editor mode, to allow multi-line expressions"],
   [".exit", "Exit the Arith REPL"],
   [".help", "Display the valid commands for Arith"],

--- a/src/help.js
+++ b/src/help.js
@@ -3,6 +3,7 @@ let help = [
   [".exit", "Exit the Arith REPL"],
   [".help", "Display the valid commands for Arith"],
   [".load", "Load a file"],
+  [".save <path/to/file>", "Save a REPL session as a file"],
   [".version", "Print the version of Arith you're using"],
 ];
 module.exports = { help };

--- a/src/help.js
+++ b/src/help.js
@@ -1,0 +1,9 @@
+let help = [
+  ["<none>, i", "Open the interpreter in interactive/REPL mode"],
+  [".editor", "Enter editor mode, to allow multi-line expressions"],
+  [".exit", "Exit the Arith REPL"],
+  [".help", "Display the valid commands for Arith"],
+  [".load", "Load a file"],
+  [".version", "Print the version of Arith you're using"],
+];
+module.exports = { help };

--- a/src/repl.js
+++ b/src/repl.js
@@ -3,36 +3,65 @@ const path = require("path");
 const { prompt } = require("inquirer");
 const chalk = require("chalk");
 const { evaluate } = require("./evaluate");
+const repl = require("repl");
+const { help } = require("./help");
 
 const version = JSON.parse(
   fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8"),
 ).version;
 
-const getInput = () => {
-  const input = [
-    {
-      name: "INPUT",
-      type: "input",
-      prefix: chalk.green(`(arith v${version}):`),
-      message: ">",
-    },
-  ];
-
-  return prompt(input);
+const eval = (cmd, context, filename, callback) => {
+  callback(null, evaluate(cmd));
 };
 
-const repl = async () => {
-  try {
-    const { INPUT } = await getInput();
-
-    if (INPUT.trim()) {
-      console.log(chalk.yellow(evaluate(INPUT)));
-    }
-  } catch (e) {
-    console.error(e);
-  }
-
-  repl();
+const initializeRepl = () => {
+  const replServer = repl.start({
+    prompt: `${chalk.green(`(arith v${version})`)}: ${chalk.white(
+      "> ",
+    )}`,
+    input: process.stdin,
+    output: process.stdout,
+    eval: eval,
+  });
+  replServer.on("exit", () => {
+    console.log("Have a nice day!");
+    process.exit();
+  });
+  replServer.defineCommand("version", {
+    help: "Displays the current version of Arith",
+    action(name) {
+      this.clearBufferedCommand();
+      console.log(`Arith version ${version}`);
+      this.displayPrompt();
+    },
+  });
+  replServer.defineCommand("help", {
+    help: "Displays the valid commands in Arith",
+    action(name) {
+      this.clearBufferedCommand();
+      console.log(
+        chalk.cyan(
+          "Welcome to Arith - a simple, Lisp-like programming language.\n",
+        ),
+      );
+      console.log(`You are using Arith ${version}`);
+      console.log(chalk.blue("Here are the valid commands:\n"));
+      console.log("COMMAND", "                DESCRIPTION");
+      help.map(([command, description]) =>
+        command.length >= 6
+          ? console.log(command, `\t\t${description}`)
+          : console.log(command, `\t\t\t${description}`),
+      );
+      console.log(); // blank line
+      console.log(
+        chalk.cyan(
+          "Use the command 'arc <file>' to transpile its contents to JavaScript.\n",
+        ),
+      );
+      console.log("Enjoy!");
+      this.displayPrompt();
+    },
+  });
 };
 
 if (require.main === module) {
@@ -41,7 +70,7 @@ if (require.main === module) {
       `*** Welcome to the Arith programming language, v${version} ***`,
     ),
   );
-  repl();
+  initializeRepl();
 }
 
-module.exports = { repl };
+module.exports = { initializeRepl };

--- a/src/repl.js
+++ b/src/repl.js
@@ -16,7 +16,7 @@ function eval(cmd, context, fileName, callback) {
   for (let i = 0; i < cmd.length; i++) {
     if (cmd[i] === "(") {
       openParenCount++;
-    } else if (cmd[i] == ")") {
+    } else if (cmd[i] === ")") {
       closeParenCount++;
     }
   }
@@ -70,29 +70,6 @@ const initializeRepl = () => {
     action(name) {
       this.clearBufferedCommand();
       console.log(`Arith version ${version}`);
-      this.displayPrompt();
-    },
-  });
-  replServer.defineCommand("help", {
-    help: "Displays the valid commands in Arith",
-    action(name) {
-      this.clearBufferedCommand();
-      console.log(
-        chalk.cyan(
-          "Welcome to Arith - a simple, Lisp-like programming language.\n",
-        ),
-      );
-      console.log(`You are using Arith ${version}`);
-      console.log(chalk.blue("Here are the valid commands:\n"));
-      console.log("COMMAND", "                DESCRIPTION");
-      help.map(([command, description]) =>
-        command.length >= 12
-          ? console.log(command, `\t${description}`)
-          : command.length >= 6
-          ? console.log(command, `\t\t${description}`)
-          : console.log(command, `\t\t\t${description}`),
-      );
-      console.log("\nEnjoy!");
       this.displayPrompt();
     },
   });

--- a/src/repl.js
+++ b/src/repl.js
@@ -3,7 +3,6 @@ const path = require("path");
 const chalk = require("chalk");
 const { evaluate } = require("./evaluate");
 const repl = require("repl");
-const { help } = require("./help");
 const vm = require("vm");
 
 const version = JSON.parse(


### PR DESCRIPTION
All right, so:

In a Node REPL, commands are prefaced with a ".", so your commands in-repl are going to be slightly different than the ones out of repl.  I couldn't figure out a way to load a file in-repl without making use of the ".load" command or how to allow multi-line without use of the "editor" command, but they work if you use them.

I created a "help.js" folder that contains an array of all of the help commands and descriptions available in-repl.  The hope is that that should make it easier for you to update as you move forward.  Since the commands are slightly different for the out-of-repl versions, I left those as they were for the most part, other than to update the one that runs a file.

### Adds
#### In-repl commands: 
- .load
- .editor
- .exit
- .version
- .help

#### Out-of-repl commands:
- `arith <filename>` will now run a file